### PR TITLE
[chore] minor improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,33 @@
-name: ci
-on:
+name: haskell ci
+on: 
   push:
   pull_request:
-  schedule:
-  - cron:  '0 3 * * 6' # 3am Saturday
+  workflow_dispatch:
 jobs:
-  test:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.7.0
+        with:
+          cabal-file: placeholder.cabal
+          ubuntu-version: latest
+          macos-version: latest
+          version: 0.1.7.0
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: ['9.8', '9.6', '9.4']
-    steps:
-    - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v2
-      id: setup-haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-    - run: cabal new-build all
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps: 
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - run: cabal new-build all

--- a/placeholder.cabal
+++ b/placeholder.cabal
@@ -12,6 +12,7 @@ copyright: Copyright (c) 2024 Edward Kmett
 stability: experimental
 category: Control
 build-type: Simple
+tested-with: GHC ==9.4.8 || ==9.6.4 || ==9.8.1
 extra-doc-files:
   README.md,
   CHANGELOG.md

--- a/src/Control/Placeholder.hs
+++ b/src/Control/Placeholder.hs
@@ -14,6 +14,9 @@
 #define WARNING_IN_XTODO WARNING
 #endif
 
+{- | The 'Control.Placeholder' module implements various functions to indicate 
+     unfinished or generally unimplemented code 
+-}
 module Control.Placeholder
   (
   -- * Combinators
@@ -52,7 +55,7 @@ pattern TodoException :: TodoException
 pattern TodoException <- TodoExceptionWithLocation _ where
   TodoException = TodoExceptionWithLocation missingLocation
 
--- | This is the 'Exception' thrown by 'unimplmented', 'Unimplemented', and 'unimplementedIO'.
+-- | This is the 'Exception' thrown by 'unimplemented', 'Unimplemented', and 'unimplementedIO'.
 data UnimplementedException = UnimplementedExceptionWithLocation String
   deriving (Typeable, Exception)
 
@@ -72,7 +75,7 @@ withCallStack f stk = unsafeDupablePerformIO $ do
     implicitParamCallStack = prettyCallStackLines stk
     ccsCallStack = showCCSStack ccsStack
     stack = intercalate "\n" $ implicitParamCallStack ++ ccsCallStack
-  return $ toException (f stack)
+  pure $ toException (f stack)
 
 {- | 'todo' indicates unfinished code.
 
@@ -101,11 +104,11 @@ superComplexFunction 'Nothing' = 'pure' 42
 superComplexFunction ('Just' a) = 'todo'
 @
 -}
-todo :: forall (r :: RuntimeRep) (a :: TYPE r). HasCallStack => a
+todo :: forall {r :: RuntimeRep} (a :: TYPE r). HasCallStack => a
 todo = raise# (withCallStack TodoExceptionWithLocation ?callStack)
 {-# WARNING_IN_XTODO todo "'todo' left in code" #-}
 
-{- | 'todoIO' indicates unfinished code that should live in the IO monad.
+{- | 'todoIO' indicates unfinished code that lives in the IO monad.
 
 It should be used similarly to how 'throwIO' should be used rather than 'throw' in IO
 to throw at the time the IO action is run rather than at the time it is created.
@@ -130,11 +133,11 @@ pattern TODO <- (raise# (withCallStack TodoExceptionWithLocation ?callStack) -> 
 {-# COMPLETE TODO #-}
 
 {- | 'unimplemented' indicates that the relevant code is unimplemented. Unlike 'todo', it is expected that this _may_ remain in code
-long term, and so no warning is supplied. Usecases might include places where a typeclass would theoretically require a member to be
+long term, and so no warning is supplied. Use cases might include places where a typeclass would theoretically require a member to be
 implemented, but where the resulting violation is actually intended.
 -}
 
-unimplemented :: forall (r :: RuntimeRep) (a :: TYPE r). HasCallStack => a
+unimplemented :: forall {r :: RuntimeRep} (a :: TYPE r). HasCallStack => a
 unimplemented = raise# (withCallStack UnimplementedExceptionWithLocation ?callStack)
 
 {- | 'unimplementedIO' indicates that the method is unimplemented, but it lives in IO, and so only throws when actually run, rather


### PR DESCRIPTION
- spelling corrections
- use tested-with stanza and get-tested
  - use `get-tested` by @kleidukos to extract cabal versions to test with directly from `tested-with` stanza
  - allow `workflow_dispatch`, don't waste ci minutes on cron jobs
- use implicit argument for runtime rep for better type application
  - I expect these to be used with type applications rarely, however, I think this would 
    prevent unnecessary confusion, especially as e.g. ghci doesn't display explicit runtime
    reps on its own
- document the module header

I also have a question to @ekmett: is there a specific reason why the exception types are `data`, not `newtype`? 