### PR TITLE
enable dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: haskell ci
-on: 
+on:
   push:
   pull_request:
   workflow_dispatch:
 jobs:
   generate-matrix:
     name: "Generate matrix from cabal"
-    outputs: 
+    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
     steps:
@@ -25,12 +25,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    steps: 
+    steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
+      - run: cabal freeze --enable-tests
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal build all
       - run: cabal test --test-option=--color=always --test-show-details=always test:placeholder-test
       - run: cabal test --enable-profiling --test-option=--color=always --test-show-details=always test:placeholder-test


### PR DESCRIPTION
add stanzas to the CI workflow that utilize dependency caching to help speed testing up.